### PR TITLE
fix: axios baseUrl to match new domain

### DIFF
--- a/src/config/axios.ts
+++ b/src/config/axios.ts
@@ -2,5 +2,5 @@ import axios from "axios"
 
 export const api = axios.create({
   withCredentials: true,
-  baseURL: "https://hermes-api.dcism.org",
+  baseURL: "https://hermes.dcism.org",
 })


### PR DESCRIPTION
# Description

We moved our domain from `hermes-api.dcism.org` to `hermes.dcism.org`.