### PR TITLE
[BS] prevent loader from showing on subsequent fetches

### DIFF
--- a/src/components/queue-card/QueueCard.tsx
+++ b/src/components/queue-card/QueueCard.tsx
@@ -42,6 +42,7 @@ const QueueCard: React.FC<QueueCardProps> = ({
   const { studentQueueData } = useStudentQueueData(jwtToken as string)
   const course = convertProgramEnumToCourseNameEnum(program)
   const [isInQueue, setIsInQueue] = useState(false)
+  const [isFirstLoad, setIsFirstLoad] = useState(true)
 
   const isStudentCourse = jwtCourse === course
 
@@ -95,7 +96,11 @@ const QueueCard: React.FC<QueueCardProps> = ({
     }
   }, [studentQueueData])
 
-  if (studentQueueData.isLoading)
+  useEffect(() => {
+    setIsFirstLoad(false)
+  }, [])
+
+  if (isFirstLoad && studentQueueData.isLoading)
     return (
       <Card shadow="sm" padding="lg" h={200} radius="lg" maw="22rem" w="100%">
         <div className="flex h-full w-full items-center justify-center">


### PR DESCRIPTION
# Description

- Improve UX by preventing the loader on the queue cards from showing on subsequent fetches

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review

- [X] I have performed a self-review of my code

## Screenshot of changes (if appropriate)
![chrome_9nzfqc1ZxA](https://github.com/user-attachments/assets/8f2ed843-4e25-49dd-a73c-1b7bb49307f6)
