### PR TITLE
feat: add a confirmation modal for admins to dequeue student

### DIFF
--- a/src/components/queue-card/AdminControls.tsx
+++ b/src/components/queue-card/AdminControls.tsx
@@ -4,6 +4,7 @@ import { Flex, Select } from "@mantine/core"
 import { ChevronDown } from "lucide-react"
 
 import { TeacherStatusEnum } from "../../types/enums/TeacherStatusEnum"
+import DequeueConfirmModal from "./DequeueConfirmModal"
 import QueueButton from "./QueueButton"
 
 interface AdminControlsProps {
@@ -15,10 +16,18 @@ interface AdminControlsProps {
 }
 
 const AdminControls: React.FC<AdminControlsProps> = ({ status, disabled, onUpdateQueue, onStatusChange }) => {
+  let openConfirmationModal
+
+  if (onUpdateQueue) {
+    openConfirmationModal = () => {
+      DequeueConfirmModal.open({ onConfirm: () => onUpdateQueue() })
+    }
+  }
+
   return (
     <Flex direction="row" gap="xs" justify="space-between" w="100%">
       <QueueButton
-        handleClick={onUpdateQueue || (() => {})}
+        handleClick={openConfirmationModal || (() => {})}
         label="Update Queue"
         disabled={disabled}
         fullWidth={false}

--- a/src/components/queue-card/DequeueConfirmModal.tsx
+++ b/src/components/queue-card/DequeueConfirmModal.tsx
@@ -1,0 +1,67 @@
+import { Text } from "@mantine/core"
+import { modals } from "@mantine/modals"
+
+interface RevokeModalProps {
+  onConfirm: () => void
+}
+
+const DequeueConfirmModal = {
+  open: ({ onConfirm }: RevokeModalProps) => {
+    return modals.openConfirmModal({
+      title: "Remove from Queue",
+      centered: true,
+      children: (
+        <Text size="sm">Are you sure you want to remove this student from the queue? This action cannot be undone</Text>
+      ),
+      labels: {
+        confirm: "Dequeue Student",
+        cancel: "Cancel",
+      },
+      confirmProps: {
+        color: "red",
+        radius: "md",
+        styles: {
+          root: {
+            backgroundColor: "#FF5757",
+            "&:hover": {
+              backgroundColor: "#ff4242",
+            },
+          },
+        },
+      },
+      cancelProps: {
+        variant: "default",
+        radius: "md",
+        color: "gray",
+        styles: {
+          root: {
+            color: "#666",
+            borderColor: "#ddd",
+            "&:hover": {
+              backgroundColor: "#f5f5f5",
+            },
+          },
+        },
+      },
+      styles: {
+        header: {
+          marginBottom: "0.5rem",
+        },
+        title: {
+          fontWeight: 600,
+        },
+        close: {
+          color: "black", // Set close button color to black
+          "&:hover": {
+            backgroundColor: "transparent", // Optional: Transparent background on hover
+          },
+        },
+      },
+      onConfirm: () => {
+        onConfirm()
+      },
+    })
+  },
+}
+
+export default DequeueConfirmModal

--- a/src/components/queue-card/DequeueConfirmModal.tsx
+++ b/src/components/queue-card/DequeueConfirmModal.tsx
@@ -1,12 +1,12 @@
 import { Text } from "@mantine/core"
 import { modals } from "@mantine/modals"
 
-interface RevokeModalProps {
+interface DequeueConfirmModalProps {
   onConfirm: () => void
 }
 
 const DequeueConfirmModal = {
-  open: ({ onConfirm }: RevokeModalProps) => {
+  open: ({ onConfirm }: DequeueConfirmModalProps) => {
     return modals.openConfirmModal({
       title: "Remove from Queue",
       centered: true,


### PR DESCRIPTION
- add a modal to confirm dequeue-ing a student from admin page
![image](https://github.com/user-attachments/assets/ae4091de-4275-44a4-a81c-68e31b596e3f)