### PR TITLE
fix(studentQueueData): cache and revalidate data to fix needless requests and stale data being displayed

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,15 +5,15 @@ import CardLoader from "./components/layout/CardLoader"
 import QueueCard from "./components/queue-card/QueueCard"
 import UserQueueInfoCard from "./components/user-info/UserQueueInfoCard"
 import { useAuth } from "./contexts/AuthContext"
+import { useQueue } from "./contexts/QueueContext"
 import { useQueueData } from "./hooks/useQueueData"
-import { useStudentQueueData } from "./hooks/useStudentQueueData"
 import { CourseNameEnum } from "./types/enums/CourseNameEnum"
 import { ProgramEnum } from "./types/enums/ProgramsEnum"
 import { TeacherStatusEnum } from "./types/enums/TeacherStatusEnum"
 
 function App() {
-  const { jwtToken, setSubmittedCourse } = useAuth()
-  const { studentQueueData } = useStudentQueueData(jwtToken as string)
+  const { setSubmittedCourse } = useAuth()
+  const { studentData } = useQueue()
 
   const queues = [
     { program: ProgramEnum.CS, course: CourseNameEnum.BSCS },
@@ -35,9 +35,7 @@ function App() {
     return { max: queue?.numberData.data?.max, current: queue?.numberData.data?.current, courseName }
   }
 
-  const { max, current, courseName } = studentQueueData.data?.courseName
-    ? getQueueStatus(studentQueueData.data?.courseName)
-    : {}
+  const { max, current, courseName } = studentData?.courseName ? getQueueStatus(studentData.courseName) : {}
 
   useEffect(() => {
     if (courseName) {
@@ -45,37 +43,37 @@ function App() {
     }
   }, [setSubmittedCourse, courseName])
 
+  console.log()
+
   return (
-    <>
-      <div className="mx-8 flex flex-col items-center gap-4 py-8">
-        {studentQueueData.data && !studentQueueData.error && courseName ? (
-          <>
-            <CoordinatorCard course={courseName} />
-            <UserQueueInfoCard userNumber={studentQueueData.data?.queueNumber} current={current} total={max} />
-          </>
-        ) : null}
-        {queueData.map((data, index) => {
-          const { numberData, coordinatorData } = data
+    <div className="mx-8 flex flex-col items-center gap-4 py-8">
+      {studentData && !studentData.error && courseName ? (
+        <>
+          <CoordinatorCard course={courseName} />
+          <UserQueueInfoCard userNumber={studentData.queueNumber} current={current} total={max} />
+        </>
+      ) : null}
+      {queueData.map((data, index) => {
+        const { numberData, coordinatorData } = data
 
-          if (numberData.error || coordinatorData.error) return <div key={index}>Error Loading Data</div>
-          if (!numberData.data || !coordinatorData.data) return <CardLoader key={index} />
+        if (numberData.error || coordinatorData.error) return <div key={index}>Error Loading Data</div>
+        if (!numberData.data || !coordinatorData.data) return <CardLoader key={index} />
 
-          const status = coordinatorData.data.status.toUpperCase() as keyof typeof TeacherStatusEnum
-          const teacherStatus = TeacherStatusEnum[status]
+        const status = coordinatorData.data.status.toUpperCase() as keyof typeof TeacherStatusEnum
+        const teacherStatus = TeacherStatusEnum[status]
 
-          return (
-            <QueueCard
-              key={index}
-              program={queues[index].program}
-              current={numberData.data.current}
-              total={numberData.data.max}
-              status={teacherStatus}
-              teacher={coordinatorData.data.name}
-            />
-          )
-        })}
-      </div>
-    </>
+        return (
+          <QueueCard
+            key={index}
+            program={queues[index].program}
+            current={numberData.data.current}
+            total={numberData.data.max}
+            status={teacherStatus}
+            teacher={coordinatorData.data.name}
+          />
+        )
+      })}
+    </div>
   )
 }
 

--- a/src/contexts/QueueContext.tsx
+++ b/src/contexts/QueueContext.tsx
@@ -11,6 +11,11 @@ interface QueueContextType {
   isFirstLoad: boolean
   isLoading: boolean
   hasError: boolean
+  studentData: {
+    queueNumber: number | undefined
+    courseName: CourseNameEnum | undefined
+    error?: Error
+  } | null
   handleEnqueue: (course: CourseNameEnum) => Promise<void>
   handleDequeue: () => Promise<void>
 }
@@ -71,7 +76,7 @@ export const QueueProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     if (studentQueueData?.data?.queueNumber !== undefined) {
       setIsInQueue(studentQueueData.data.queueNumber !== null)
     }
-  }, [studentQueueData])
+  }, [studentQueueData, jwtToken])
 
   useEffect(() => {
     setIsFirstLoad(false)
@@ -82,6 +87,13 @@ export const QueueProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     isFirstLoad,
     isLoading: studentQueueData.isLoading,
     hasError: !!studentQueueData.error,
+    studentData: studentQueueData.data
+      ? {
+          queueNumber: studentQueueData.data.queueNumber,
+          courseName: studentQueueData.data.courseName,
+          error: studentQueueData.error,
+        }
+      : null,
     handleEnqueue,
     handleDequeue,
   }

--- a/src/hooks/useStudentQueueData.ts
+++ b/src/hooks/useStudentQueueData.ts
@@ -4,9 +4,22 @@ import { QueueService } from "../services/queue.service"
 import { POLLING_INTERVAL } from "../types/constants/polling-interval"
 
 export const useStudentQueueData = (accessToken: string) => {
-  const studentQueueData = useSWR(`queue/number`, () => QueueService.findQueueNumber(accessToken), {
-    refreshInterval: POLLING_INTERVAL,
-  })
+  const { data, error, isLoading, mutate } = useSWR(
+    accessToken ? `queue/number` : null,
+    () => QueueService.findQueueNumber(accessToken),
+    {
+      refreshInterval: POLLING_INTERVAL,
+      revalidateOnFocus: true,
+      revalidateIfStale: true,
+    },
+  )
 
-  return { studentQueueData }
+  return {
+    studentQueueData: {
+      data,
+      error,
+      isLoading,
+    },
+    mutate,
+  }
 }


### PR DESCRIPTION
# The Problem

- useSWR was polling and fetching for `studentQueueData` on every single route regardless of whether it is needed or not (it is not needed in the auth page or the admin page). This also resulted in stale data being shown briefly when students would login, queue up, and then logout and login as another user (@elderfieldzeus's issue in the GC).
- The data fetching was also doubled since `App.tsx` was using its own useSWR apart from what is done in `QueueContext`.

# The Solution

- Rather than just polling for data endlessly, risking stale data being shown, data is now cached once initially fetched, and then revalidated on these cases: 1.) Initial Load, 2.) On Enqueue, 3.) On Dequeue. Now every login should cause data to be stale and revalidate the data. Same with enqueue-ing and dequeue-ing.
- Refactored `App.tsx` to not do its own data fetching but just utilize existing contexts.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.

## Screenshot of changes (if appropriate)

### No more fetching of studentQueueData on auth page and on coordinator view
![image](https://github.com/user-attachments/assets/87365364-8629-4de3-8580-70614978919f)
![image](https://github.com/user-attachments/assets/af7b7112-de56-428e-891d-1848fb390f0b)

