### PR TITLE
fix(zoom): fix unnecessary zooming in anti-feature of Apple Safari

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <!-- <a href="https://www.vecteezy.com/free-vector/illustration">Illustration Vectors by Vecteezy</a> -->
     <link rel="icon" type="image/svg+xml" href="/logo-white.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0 maximum-scale=1" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link


### PR DESCRIPTION
# Description

<img width="684" alt="image" src="https://github.com/user-attachments/assets/7e54b611-86c1-4915-b630-dcb2e80a6219" />

Added `maximum-scale=1` to `index.html` 

Fixes #67 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review

- [x] I have performed a self-review of my code

## Screenshot of changes (if appropriate)

N/A. Please refer to #67 solution.