### PR TITLE
[BS] Fix deploy v2

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,4 +23,4 @@ jobs:
             git reset --hard && git clean -fd && git pull origin main
             npm ci
             npm run build
-            rsync -arvz --delete ./dist/ ~/${{ secrets.DCISM_DOMAIN }}/
+            rsync -avz --delete ./dist/ ~/${{ secrets.DCISM_DOMAIN }}/

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,4 +23,4 @@ jobs:
             git reset --hard && git clean -fd && git pull origin main
             npm ci
             npm run build
-            mv -f ./dist/* ~/${{ secrets.DCISM_DOMAIN }}
+            rsync -arz --delete ./dist/ ~/${{ secrets.DCISM_DOMAIN }}/

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,4 +23,4 @@ jobs:
             git reset --hard && git clean -fd && git pull origin main
             npm ci
             npm run build
-            rsync -arz --delete ./dist/ ~/${{ secrets.DCISM_DOMAIN }}/
+            rsync -arvz --delete ./dist/ ~/${{ secrets.DCISM_DOMAIN }}/

--- a/docs/server-setup-guide.md
+++ b/docs/server-setup-guide.md
@@ -40,7 +40,7 @@ The files are, by default, stored in `dist/`, so move them to the project root
 to prevent having to go to `/dist` on the URL.
 
 ```bash
-mv -f ./dist/* ~/queue.dcism.org
+rsync -arz --delete ./dist/ ~/queue.dcism.org/
 ```
 
 Once this setup is complete, you can proceed with the `deploy.yml` workflow.

--- a/docs/server-setup-guide.md
+++ b/docs/server-setup-guide.md
@@ -40,7 +40,7 @@ The files are, by default, stored in `dist/`, so move them to the project root
 to prevent having to go to `/dist` on the URL.
 
 ```bash
-rsync -arz --delete ./dist/ ~/queue.dcism.org/
+rsync -arvz --delete ./dist/ ~/queue.dcism.org/
 ```
 
 Once this setup is complete, you can proceed with the `deploy.yml` workflow.

--- a/docs/server-setup-guide.md
+++ b/docs/server-setup-guide.md
@@ -40,7 +40,7 @@ The files are, by default, stored in `dist/`, so move them to the project root
 to prevent having to go to `/dist` on the URL.
 
 ```bash
-rsync -arvz --delete ./dist/ ~/queue.dcism.org/
+rsync -avz --delete ./dist/ ~/queue.dcism.org/
 ```
 
 Once this setup is complete, you can proceed with the `deploy.yml` workflow.


### PR DESCRIPTION
# Description

Using `mv` results in an error since there's a non-empty directory under `queue.dcism.org`. To work around this, we switch to `rsync` to just sync the data between the old build and the new build.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] This change requires a documentation update

## Checklist before requesting a review

- [X] I have performed a self-review of my code

## Screenshot of changes (if appropriate)